### PR TITLE
Slow Add ETH Wallet Modal Display #104

### DIFF
--- a/AddEthereumWalletViewController.swift
+++ b/AddEthereumWalletViewController.swift
@@ -523,11 +523,16 @@ class AddEthereumWalletViewController: UIViewController, UITextFieldDelegate, AV
             session.addOutput(output)
             output.metadataObjectTypes = output.availableMetadataObjectTypes
 
-            cameraPreviewLayer.session = session
-            cameraPreviewLayer.videoGravity = .resizeAspectFill
-            cameraPreviewView.layer.addSublayer(cameraPreviewLayer)
-            cameraPreviewView.layer.addSublayer(cameraHighlightBoxLayer)
-            session.startRunning()
+            DispatchQueue.utility.async {
+                session.startRunning()
+
+                DispatchQueue.main.async {
+                    self.cameraPreviewLayer.session = session
+                    self.cameraPreviewLayer.videoGravity = .resizeAspectFill
+                    self.cameraPreviewView.layer.addSublayer(self.cameraPreviewLayer)
+                    self.cameraPreviewView.layer.addSublayer(self.cameraHighlightBoxLayer)
+                }
+             }
         } catch {
             print("Failed to create AVCaptureSession: \(error)")
         }


### PR DESCRIPTION
When AVCaptureSession is ready to start running,
the call should be done on a separate thread to
stop the UI from blocking.

- Dispatch startRunning() call to utility queue.
- After startRunning() finishes, set view on main thread.

Fixes #104.