### PR TITLE
iPhone SE Wallet Address Label Overflow

### DIFF
--- a/Balance/Table Cells/NamedWalletTableViewCell.swift
+++ b/Balance/Table Cells/NamedWalletTableViewCell.swift
@@ -6,6 +6,8 @@ class NamedWalletTableViewCell: WalletTableViewCell {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         label.text = "Ethereum Wallet"
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.5
         label.textColor = .black
         return label
     }()
@@ -38,7 +40,7 @@ class NamedWalletTableViewCell: WalletTableViewCell {
         addressLabel.snp.makeConstraints { make in
             make.top.equalTo(nameLabel.snp.bottom).offset(10)
             make.leading.equalToSuperview().offset(15)
-            make.trailing.equalToSuperview().offset(15)
+            make.trailing.equalToSuperview().offset(-15)
         }
     }
     

--- a/Balance/Views/WalletInfoView.swift
+++ b/Balance/Views/WalletInfoView.swift
@@ -163,8 +163,8 @@ class WalletInfoView: UIView {
             make.top.equalTo(qrCodeImageView.snp.bottom).offset(20)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-20)
-            make.leading.equalTo(qrCodeImageView.snp.leading)
-            make.trailing.equalTo(qrCodeImageView.snp.trailing)
+            make.leading.equalTo(qrCodeImageView)
+            make.trailing.equalTo(qrCodeImageView)
         }
     }
 

--- a/Balance/Views/WalletInfoView.swift
+++ b/Balance/Views/WalletInfoView.swift
@@ -37,6 +37,9 @@ class WalletInfoView: UIView {
         let addressLabel = UILabel()
         addressLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 12, weight: .regular)
         addressLabel.textColor = .white
+        addressLabel.adjustsFontSizeToFitWidth = true
+        addressLabel.minimumScaleFactor = 0.3
+        addressLabel.numberOfLines = 1
         return addressLabel
     }()
     
@@ -160,6 +163,8 @@ class WalletInfoView: UIView {
             make.top.equalTo(qrCodeImageView.snp.bottom).offset(20)
             make.centerX.equalToSuperview()
             make.bottom.equalToSuperview().offset(-20)
+            make.leading.equalTo(qrCodeImageView.snp.leading)
+            make.trailing.equalTo(qrCodeImageView.snp.trailing)
         }
     }
 


### PR DESCRIPTION
- Allow text to shrink to min factor.
- Set leading/trailing edges to line up with qr code.
- Fix in modal and table view cell.

Fixes #119.