### PR TITLE
Make the buttons 45% screen size

### DIFF
--- a/Balance/View Controllers/Tabs/SettingsViewController.swift
+++ b/Balance/View Controllers/Tabs/SettingsViewController.swift
@@ -201,7 +201,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         mediumButton.snp.makeConstraints { make in
             make.top.equalTo(joinSubtitleLabel.snp.bottom).offset(15)
             make.centerX.equalToSuperview().multipliedBy(0.5)
-            make.width.equalTo(167)
+            make.width.equalToSuperview().multipliedBy(0.45)
             make.height.equalTo(47)
         }
         mediumButton.imageView?.snp.makeConstraints { make in


### PR DESCRIPTION
Fixes #132 Making all buttons 45% of the screen size
(screenshot for iPhone SE)
![Simulator Screen Shot - iPhone SE - 2019-03-31 at 10 42 42](https://user-images.githubusercontent.com/1092080/55286927-a9cb6f80-53a2-11e9-8412-e9f69efcf4ca.png)