### PR TITLE
Fix Issue with Add Wallet Button Touch when Keyboard Open (#147)

### DIFF
--- a/AddEthereumWalletViewController.swift
+++ b/AddEthereumWalletViewController.swift
@@ -229,6 +229,10 @@ class AddEthereumWalletViewController: UIViewController, UITextFieldDelegate, AV
 
     // MARK - View Lifecycle -
 
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return touch.view != addButton
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/AddEthereumWalletViewController.swift
+++ b/AddEthereumWalletViewController.swift
@@ -526,6 +526,8 @@ class AddEthereumWalletViewController: UIViewController, UITextFieldDelegate, AV
             return
         }
 
+        view.endEditing(true)
+
         let ethereumWallet = EthereumWallet(name: nameTextField.text, address: address, includeInTotal: includeInTotalSwitch.isOn)
 
         CoreDataHelper.save(ethereumWallet: ethereumWallet)

--- a/Balance/Extensions/UIViewController+UI.swift
+++ b/Balance/Extensions/UIViewController+UI.swift
@@ -8,10 +8,11 @@
 
 import UIKit
 
-extension UIViewController {
+extension UIViewController: UIGestureRecognizerDelegate {
     func dismissKeyBoardOnScreenTouch() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
+        tap.delegate = self
         view.addGestureRecognizer(tap)
     }
 


### PR DESCRIPTION
Even with the tap gesture cancelTouchesInView set to false,
the keyboard dismiss action causes the add action to not fire.
The solution is to look if the Add button is what was touched
and allow it to continue if so.

- Set delegate to self in extension.
- Define gestureRecognizer touch receiver method.
- Tell view to dismiss keyboard (end editing) when Add touched.

Fixes #147