### PR TITLE
Compute sections list at get time

### DIFF
--- a/Balance/Table Cells/CryptoBalanceTableViewCell.swift
+++ b/Balance/Table Cells/CryptoBalanceTableViewCell.swift
@@ -442,7 +442,7 @@ private class CryptoRow: UIView {
             make.top.equalTo(rateLabel)
         }
 
-        var cryptoBalance = "-"
+        var cryptoBalance = "0.00"
 
         // TODO: - Fix this for multi-currency
         if let rate = rate {


### PR DESCRIPTION
This PR resolves #179.

It also changes the default '-' value to '0.00'. There's no meaningful difference between having none of a given token and having 0 of that tokens. (c.f. the difference between not having a measurement, and having a measurement and that measurement being 0).